### PR TITLE
Faster initialization by using length of shared prefix.

### DIFF
--- a/plugin/fuzzy_file_finder.rb
+++ b/plugin/fuzzy_file_finder.rb
@@ -117,6 +117,9 @@ class FuzzyFileFinder
     @roots = directories.map { |d| File.expand_path(d) }.select { |d| File.directory?(d) }.uniq
 
     @shared_prefix = determine_shared_prefix.length
+    if @shared_prefix > 0
+      @shared_prefix += 1
+    end
 
     @files = []
     @cache = {}

--- a/plugin/fuzzy_file_finder.rb
+++ b/plugin/fuzzy_file_finder.rb
@@ -116,8 +116,7 @@ class FuzzyFileFinder
     # expand any paths with ~
     @roots = directories.map { |d| File.expand_path(d) }.select { |d| File.directory?(d) }.uniq
 
-    @shared_prefix = determine_shared_prefix
-    @shared_prefix_re = Regexp.new("^#{Regexp.escape(shared_prefix)}" + (shared_prefix.empty? ? "" : "/"))
+    @shared_prefix = determine_shared_prefix.length
 
     @files = []
     @cache = {}
@@ -229,7 +228,7 @@ class FuzzyFileFinder
 
         if File.directory?(full) && File.readable?(full)
           follow_tree(full)
-        elsif !ignore?(full.sub(@shared_prefix_re, ""))
+        elsif !ignore?(full[@shared_prefix..-1])
           files.push(FileSystemEntry.new(directory, entry, full))
           raise TooManyEntries if files.length > ceiling
         end
@@ -310,7 +309,7 @@ class FuzzyFileFinder
       return path_matches[path] if path_matches.key?(path)
 
       name_with_slash = path + "/" # add a trailing slash for matching the prefix
-      matchable_name = name_with_slash.sub(@shared_prefix_re, "")
+      matchable_name = name_with_slash[@shared_prefix..-1]
       matchable_name.chop! # kill the trailing slash
 
       if path_regex

--- a/plugin/fuzzyfinder_textmate.vim
+++ b/plugin/fuzzyfinder_textmate.vim
@@ -76,7 +76,7 @@ ruby << RUBY
       fuzzy_roots = VIM.evaluate("g:fuzzy_roots")
       roots = fuzzy_roots.respond_to?(:split) ? fuzzy_roots.split("\n") : fuzzy_roots
       ceiling = VIM.evaluate("g:fuzzy_ceiling").to_i
-      ignore = VIM.evaluate("g:fuzzy_ignore").split(/[;,]/)
+      ignore = VIM.evaluate("g:fuzzy_ignore")
       FuzzyFileFinder.new(roots, ceiling, ignore)
     end
   end


### PR DESCRIPTION
Store the length of the shared prefix and use slice instead of regexp for a 10+% speedup.
